### PR TITLE
Use hasMagic to make glob prefix optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,25 @@ have a directory layout like this:
 In `index.js` you can write:
 
 ```js
+import { main, _partial } from 'templates/*.handlebars.js'
+```
+
+You can add an optional `glob:` prefix:
+
+```js
 import { main, _partial } from 'glob:templates/*.handlebars.js'
 ```
 
 You can alias members:
 
 ```js
-import { main, _partial as partial } from 'glob:templates/*.handlebars.js'
+import { main, _partial as partial } from 'templates/*.handlebars.js'
 ```
 
 Or import all matches into a namespace object:
 
 ```js
-import * as templates from 'glob:templates/*.handlebars.js'
+import * as templates from 'templates/*.handlebars.js'
 // Provides `templates.main` and `templates._partial`
 ```
 
@@ -64,13 +70,13 @@ Note that you **cannot import the default** from the glob pattern. The following
 **won't work** and throws a `SyntaxError`:
 
 ```js
-import myTemplates from 'glob:templates/*.handlebars.js' // This will throw a SyntaxError
+import myTemplates from 'templates/*.handlebars.js' // This will throw a SyntaxError
 ```
 
 You can load modules for their side-effects though:
 
 ```js
-import 'glob:modules-with-side-effects/*.js'
+import 'modules-with-side-effects/*.js'
 ```
 
 ### Glob patterns
@@ -110,7 +116,7 @@ A `SyntaxError` is throw when importing a member that does not correspond to a
 match:
 
 ```js
-import { doesNotExist } from 'glob:templates/*.handlebars.js' // This will throw a SyntaxError
+import { doesNotExist } from 'templates/*.handlebars.js' // This will throw a SyntaxError
 ```
 
 Here's an overview of how the members are determined for additional matches.

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,11 @@ export default function ({ types: t }) {
     visitor: {
       ImportDeclaration (path, file) {
         const { node: { specifiers, source } } = path
-        if (!t.isStringLiteral(source) || !/^glob:/.test(source.value)) {
+        if (!t.isStringLiteral(source)) {
+          return
+        }
+
+        if (!/^glob:/.test(source.value) && !glob.hasMagic(source.value)) {
           return
         }
 

--- a/test/import-glob.js
+++ b/test/import-glob.js
@@ -69,6 +69,19 @@ test('rewrites the import statement', t => {
 import bar from './fixtures/multiple/bar.txt';`)
 })
 
+test('does not require glob prefix', t => {
+  t.is(
+    transform("import { foo, bar } from 'fixtures/multiple/*.txt'"),
+    `import foo from './fixtures/multiple/foo.txt';
+import bar from './fixtures/multiple/bar.txt';`)
+})
+
+test('does not transform standard import', t => {
+  t.is(
+    transform("import foo from 'fixtures/multiple/foo.txt'"),
+    `import foo from 'fixtures/multiple/foo.txt';`)
+})
+
 test('constructs the member by identifierfying the file name, without the common extname', t => {
   t.is(
     transform("import { fooBar } from 'glob:fixtures/foo-bar/*.txt'"),


### PR DESCRIPTION
This is a simple tweak that uses `glob.hasMagic` to determine if an import path is a glob pattern or not, which makes the `glob:` prefix optional.